### PR TITLE
Add `variant` library

### DIFF
--- a/.github/workflows/libraries.yml
+++ b/.github/workflows/libraries.yml
@@ -49,6 +49,48 @@ jobs:
     - name: Test
       run: cabal test behaviours
 
+  variant:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.ghcup
+          ~/.cabal/packages
+          ~/.cabal/store
+          dist-newstyle
+
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install Haskell
+      run: |
+        sudo apt-get update
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_MINIMAL=please sh
+
+        ghcup install ghc 8.10.7
+        ghcup install cabal 3.6.2.0
+
+        ghcup set ghc 8.10.7
+        ghcup set cabal 3.6.2.0
+
+    - name: Dependencies
+      run: |
+        cabal update
+        cabal build variant --only-dependencies --enable-tests --enable-benchmarks
+
+    - name: Build
+      run: cabal build variant --enable-tests
+
+    - name: Test
+      run: cabal test variant
+
   wavefront:
     runs-on: ubuntu-latest
 

--- a/variant/source/Data/Variant.hs
+++ b/variant/source/Data/Variant.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+-- | A generalised 'Either' to any number of types, rather than just two.
+module Data.Variant where
+
+import Control.Applicative (Alternative ((<|>), empty))
+import Data.Kind (Constraint, Type)
+import Type.Reflection ((:~:) (..))
+
+-- | Apply the given constraint to every item in the given list.
+type All ∷ (Type → Constraint) → [Type] → Constraint
+type family All c xs where
+  All c '[     ]  = (             )
+  All c (x ': xs) = (c x, All c xs)
+
+-- | Evidence that a given value exists in a 'Variant'.
+type Elem ∷ Type → [Type] → Type
+data Elem x xs where
+  Here ∷ Elem x (x ': xs)
+  There ∷ Elem x xs → Elem x (y ': xs)
+
+-- | Check whether two 'Elem' values point to the same element.
+equals ∷ ∀ x y xs. Elem x xs → Elem y xs → Maybe (x :~: y)
+equals  Here      Here     = Just Refl
+equals (There x) (There y) = x `equals` y
+equals  _         _        = Nothing
+
+-- | We can't produce evidence of an element existing in an empty list, so it's
+-- effectively isomorphic to 'Data.Void.Void'.
+impossible ∷ ∀ x y. Elem x '[] → y
+impossible = \case
+
+-- | One of a list of possible types. Represented by the value and evidence
+-- that its type is in the 'Variant'.
+type Variant ∷ [Type] → Type
+data Variant xs where
+  Choice ∷ Elem x xs → x → Variant xs
+
+instance All Eq xs ⇒ Eq (Variant xs) where
+  Choice  Here     x == Choice  Here     y = x == y
+  Choice (There i) x == Choice (There j) y = Choice i x == Choice j y
+  Choice  _        _ == Choice  _        _ = False
+
+instance All Show xs ⇒ Show (Variant xs) where
+  show x = fold @Show x show
+
+-- | An empty 'Variant' is isomorphic to 'Data.Void.Void'.
+preposterous ∷ ∀ x. Variant '[] → x
+preposterous (Choice i _) = case i of
+
+-- | Unwrap a singleton 'Variant'.
+unwrap ∷ ∀ x. Variant '[x] → x
+unwrap = \case
+  Choice  Here        x → x
+  Choice (There void) _ → impossible void
+
+-- | Wrap a type in a singleton 'Variant'.
+wrap ∷ ∀ x. x → Variant '[x]
+wrap = inject
+
+-- | Wrap a value in a 'Variant' that contains its type.
+type Inject ∷ [Type] → Type → Constraint
+class Inject xs x where inject ∷ x → Variant xs
+
+instance Inject (x ': xs) x where
+  inject x = Choice Here x
+
+instance {-# INCOHERENT #-} Inject xs x ⇒ Inject (y ': xs) x where
+  inject x = case inject x of Choice ix vx -> Choice (There ix) vx
+
+-- | Attempt to wrap a value in a 'Variant', failing if the 'Variant' doesn't
+-- contain its type.
+type Offer ∷ [Type] → Type → Constraint
+class Offer xs x where offer ∷ x → Maybe (Variant xs)
+
+instance Offer '[] x where
+  offer _ = Nothing
+
+instance Offer (x ': xs) x where
+  offer x = Just (Choice Here x)
+
+instance {-# INCOHERENT #-} Offer xs x
+    ⇒ Offer (y ': xs) x where
+  offer = fmap grow . offer
+
+-- | Interpret the input into the 'Variant' by attempting to build each type
+-- with an 'Alternative' function.
+type Interpret ∷ (Type → Constraint) → [Type] → Constraint
+class Interpret c xs where
+  
+  -- | Interpret the input into one of the possible outputs.
+  interpret ∷ ∀ f i. Alternative f ⇒ (∀ o. c o ⇒ i → f o) → i → f (Variant xs)
+
+instance Interpret c '[] where
+  interpret _ _ = empty
+
+instance (c x, Interpret c xs) ⇒ Interpret c (x ': xs) where
+  interpret f x = fmap (Choice Here) (f x) <|> fmap grow (interpret @c f x)
+
+-- | Apply the given function to the value in the 'Variant'.
+fold ∷ ∀ c xs r. All c xs ⇒ Variant xs → (∀ x. c x ⇒ x → r) → r
+fold (Choice i x) f = case i of
+  Here    → f x
+  There j → fold @c (Choice j x) f
+
+-- | If a value's is one of @xs@, then it's definitely also one of @x ': xs@.
+-- Note that we don't need a general purpose "variant expxander" if we keep our
+-- descriptions classy: @Inject Int xs ⇒ Variant xs@ can be concretised to
+-- @Variant '[Int]@, but also @Variant '[String, Int]@, or
+-- @Variant '[Int, ()]@, or anything else with @Int@ in it!
+grow ∷ ∀ x xs. Variant xs → Variant (x ': xs)
+grow (Choice i x) = Choice (There i) x
+
+-- | Convert one 'Variant' to another. Succeeds if the underlying value's type
+-- exists in both variants.
+translate ∷ ∀ xs ys. All (Offer ys) xs ⇒ Variant xs → Maybe (Variant ys)
+translate xs = fold @(Offer ys) xs offer

--- a/variant/tests/Data/VariantTest.hs
+++ b/variant/tests/Data/VariantTest.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UnicodeSyntax #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Data.VariantTest where
+
+import Data.Variant
+import Test.Hspec (Spec, it, shouldBe)
+import Text.Read (readMaybe)
+
+spec_Variant ∷ Spec
+spec_Variant = do
+  it "Value injection" do
+    let example ∷ xs ~ '[ String, Bool, () ] ⇒ Inject xs x => x → Variant xs
+        example = inject
+
+    example "hello" `shouldBe` Choice Here "hello"
+    example True `shouldBe` Choice (There Here) True
+    example () `shouldBe` Choice (There (There Here)) ()
+
+  it "Partial value injection" do
+    let example ∷ xs ~ '[ String, Bool, () ] ⇒ Offer xs x ⇒ x → Maybe (Variant xs)
+        example = offer
+
+    example "hello" `shouldBe` Just (Choice Here "hello")
+    example True `shouldBe` Just (Choice (There Here) True)
+    example () `shouldBe` Just (Choice (There (There Here)) ())
+    example (3 ∷ Int) `shouldBe` Nothing
+
+  it "Interpretation" do
+    let example ∷ String → Maybe (Variant '[Int, Bool])
+        example = interpret @Read @'[Int, Bool] readMaybe
+
+    example "3" `shouldBe` Just (Choice Here 3)
+    example "True" `shouldBe` Just (Choice (There Here) True)
+    example "()" `shouldBe` Nothing
+
+  it "Folding" do
+    let example ∷ Variant '[Int, Bool, String] → String
+        example x = fold @Show x show
+
+    example (Choice Here 3) `shouldBe` "3"
+    example (Choice (There Here) True) `shouldBe` "True"
+    example (Choice (There (There Here)) "hello") `shouldBe` "\"hello\""
+
+  it "Translating" do
+    let example ∷ Variant '[Int, Bool] → Maybe (Variant '[Bool, String])
+        example = translate
+
+    example (Choice Here 3) `shouldBe` Nothing
+    example (Choice (There Here) True) `shouldBe` Just (Choice Here True)

--- a/variant/tests/Driver.hs
+++ b/variant/tests/Driver.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}

--- a/variant/variant.cabal
+++ b/variant/variant.cabal
@@ -1,0 +1,30 @@
+cabal-version: 3.0
+name: variant
+version: 0.1.0.0
+
+library
+    exposed-modules:
+      Data.Variant
+    build-depends:
+      , base ^>= 4.14
+    ghc-options: -Wall -Wextra -Werror
+    hs-source-dirs: source
+    default-language: Haskell2010
+
+test-suite variant
+  build-depends:
+    , base
+    , variant
+    , hedgehog ^>= 1.1
+    , hspec ^>= 2.10
+    , tasty ^>= 1.4
+    , tasty-hspec ^>= 1.2
+  build-tool-depends:
+   tasty-discover:tasty-discover
+  default-language: Haskell2010
+  ghc-options: -Wall -Wextra -Werror
+  hs-source-dirs: tests
+  main-is: Driver.hs
+  other-modules:
+    Data.VariantTest
+  type: exitcode-stdio-1.0


### PR DESCRIPTION
It didn't really make sense in `wavefront`, and we're going to need it elsewhere anyway. I'll remove it from `wavefront` in a subsequent PR.