### PR TITLE
Add library modules to test packages

### DIFF
--- a/behaviours/behaviours.cabal
+++ b/behaviours/behaviours.cabal
@@ -3,22 +3,22 @@ name: behaviours
 version: 0.1.0.0
 
 library
-    build-depends:
-      , base ^>= 4.14
-      , containers ^>= 0.6
-      , primitive ^>= 0.7
-      , witherable ^>= 0.4
-    default-language: Haskell2010
-    exposed-modules:
-      FRP.Behaviour
-      FRP.Event
-    ghc-options: -Wall -Wextra -Werror
-    hs-source-dirs: source
+  build-depends:
+    , base ^>= 4.14
+    , containers ^>= 0.6
+    , primitive ^>= 0.7
+    , witherable ^>= 0.4
+  default-language: Haskell2010
+  exposed-modules:
+    FRP.Behaviour
+    FRP.Event
+  ghc-options: -Wall -Wextra -Werror
+  hs-source-dirs: source
 
 test-suite behaviours
   build-depends:
     , base
-    , behaviours
+    , containers
     , hedgehog ^>= 1.1
     , monad-control ^>= 1.0
     , primitive
@@ -29,9 +29,13 @@ test-suite behaviours
    tasty-discover:tasty-discover
   default-language: Haskell2010
   ghc-options: -Wall -Wextra -Werror
-  hs-source-dirs: tests
+  hs-source-dirs:
+    source
+    tests
   main-is: Driver.hs
   other-modules:
+    FRP.Behaviour
     FRP.BehaviourTest
+    FRP.Event
     FRP.EventTest
   type: exitcode-stdio-1.0

--- a/variant/variant.cabal
+++ b/variant/variant.cabal
@@ -14,7 +14,6 @@ library
 test-suite variant
   build-depends:
     , base
-    , variant
     , hedgehog ^>= 1.1
     , hspec ^>= 2.10
     , tasty ^>= 1.4
@@ -23,8 +22,11 @@ test-suite variant
    tasty-discover:tasty-discover
   default-language: Haskell2010
   ghc-options: -Wall -Wextra -Werror
-  hs-source-dirs: tests
+  hs-source-dirs:
+    source
+    tests
   main-is: Driver.hs
   other-modules:
+    Data.Variant
     Data.VariantTest
   type: exitcode-stdio-1.0

--- a/wavefront/wavefront.cabal
+++ b/wavefront/wavefront.cabal
@@ -20,17 +20,20 @@ test-suite wavefront
     , hedgehog ^>= 1.1
     , hspec ^>= 2.10
     , parsec
+    , parsec3-numbers
     , tasty ^>= 1.4
     , tasty-hedgehog ^>= 1.3
     , tasty-hspec ^>= 1.2
     , variant
-    , wavefront
   build-tool-depends:
    tasty-discover:tasty-discover
   default-language: Haskell2010
   ghc-options: -Wall -Wextra -Werror
-  hs-source-dirs: tests
+  hs-source-dirs:
+    source
+    tests
   main-is: Driver.hs
   other-modules:
+    Wavefront.Parser
     Wavefront.ParserTest
   type: exitcode-stdio-1.0


### PR DESCRIPTION
Right now, editing the library and tests at the same time is a pain. Adding the library modules to the test package means that we can just run `ghcid` on the tests and get feedback for everything.